### PR TITLE
feat: generate descriptions with metadata

### DIFF
--- a/bin/apikana
+++ b/bin/apikana
@@ -134,7 +134,7 @@ function generate() {
         var generator = plop.getGenerator('start');
         const model = Object.assign({}, packageJSON, { api: openapi });
         generator.runActions(model).then(_ => {
-            require('../src/generate').generate(path.resolve(source), params.target());
+            require('../src/generate').generate(defaults, path.resolve(source), params.target());
         });
     }
 

--- a/test/specs/sandbox.js
+++ b/test/specs/sandbox.js
@@ -67,7 +67,7 @@ module.exports = () => {
             var plop = nodePlop(`${__dirname}/../../src/plopfile_start.js`, {logLevel});
             return plop.getGenerator('start').runActions(packageJSON)
                 .then(_ => new Promise((resolve, reject) =>
-                    generator.generate('src', 'dist', (err) =>
+                    generator.generate({}, 'src', 'dist', (err) =>
                         err ? reject(err) : resolve({dir}))))
         }
     }


### PR DESCRIPTION
Appends a paths metadata to each of its methods description. Relies on an object in apikana-defaults, "metadata", containing the properties "matchProps" and "mappedKeys".
"matchProps" expects a string containing a regular expression matching the paths properties which should be handled as metadata, the default being "^x-.*$".
"mappedKeys" expects an object containing mappings for the keys contained in a metadata property, intended to make the descriptions better looking, the default is an empty object.